### PR TITLE
日期选择选中项字体大小修正为18sp

### DIFF
--- a/midialog/src/main/java/li/xiangyang/android/midialog/Select3Dialog.java
+++ b/midialog/src/main/java/li/xiangyang/android/midialog/Select3Dialog.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.graphics.Color;
+import android.util.TypedValue;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -286,11 +287,11 @@ public class Select3Dialog extends BaseDialog implements CommonListAdapter.ViewF
         vh.txt.setText(item);
 
         if (index == select + 2) {
-            vh.txt.setTextSize(dp2px(7));
+            vh.txt.setTextSize(TypedValue.COMPLEX_UNIT_SP, 18);
             vh.txt.setSelected(true);
         } else {
             vh.txt.setSelected(false);
-            vh.txt.setTextSize(dp2px(5));
+            vh.txt.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14);
         }
     }
 


### PR DESCRIPTION
TextView.setTextSize(float)默认单位为sp，dp转化后再使用sp，在一些机型上文字大小显示会有错